### PR TITLE
Fixed issue with sets number, formatting of time strings, and slightly adjusted size of interval indicator

### DIFF
--- a/app/src/main/java/com/example/intervaltimer/TimerActivity.java
+++ b/app/src/main/java/com/example/intervaltimer/TimerActivity.java
@@ -55,7 +55,7 @@ public class TimerActivity extends AppCompatActivity {
         // Get text views
         durationVal = findViewById(R.id.duration_val);
         intervalTimingVal = findViewById(R.id.interval_timing_val);
-        setsVal = findViewById(R.id.number_of_beeps_val);
+        setsVal = findViewById(R.id.sets_val);
 
         // Get progress indicators
         intervalProgressIndicator = findViewById(R.id.interval_progress_indicator);
@@ -110,7 +110,7 @@ public class TimerActivity extends AppCompatActivity {
         // Initialize text view values
         durationVal.setText(TimerUtils.formatTimeString(durationMillisInput));
         intervalTimingVal.setText(TimerUtils.formatTimeString(intervalMillisInput));
-        setsVal.setText(TimerUtils.formatSets(0, setsInput));
+        setsVal.setText(TimerUtils.formatSets(1, setsInput));
 
         startButton = findViewById(R.id.start_timer_button);
         resetButton = findViewById(R.id.reset_timer_button);

--- a/app/src/main/java/com/example/intervaltimer/timer/IntervalCountDownTimer.java
+++ b/app/src/main/java/com/example/intervaltimer/timer/IntervalCountDownTimer.java
@@ -56,7 +56,7 @@ public class IntervalCountDownTimer {
                                   int totalSets, NotificationCompat.Builder notificationBuilderProgress,
                                   NotificationCompat.Builder notificationBuilderAlarm,
                                   NotificationManagerCompat notificationManager) {
-        this.setCounter = 0;
+        this.setCounter = 1;
         this.timerIsRunning = false;
         this.totalSets = totalSets;
         this.durationView = durationView;
@@ -75,7 +75,7 @@ public class IntervalCountDownTimer {
         this.notificationBuilderAlarm = notificationBuilderAlarm;
         this.notificationManager = notificationManager;
 
-        this.intervalProgressIndicator.setTrackThickness(200);
+        this.intervalProgressIndicator.setTrackThickness(175);
     }
 
     public boolean isRunning() {
@@ -110,7 +110,7 @@ public class IntervalCountDownTimer {
         // Create new timers with initial input values
         durationTimer = createDurationTimer(totalDurationMillis);
         intervalTimer = createIntervalTimer(totalDurationMillis, totalIntervalMillis);
-        setCounter = 0;
+        setCounter = 1;
         durationMillisUntilFinished = totalDurationMillis;
         intervalMillisUntilFinished = totalIntervalMillis;
         // Reset UI test to initial values
@@ -228,14 +228,13 @@ public class IntervalCountDownTimer {
             @SuppressLint("MissingPermission")
             @Override
             public void onTick(long millisUntilFinished) {
-                setsView.setText(TimerUtils.formatSets(setCounter, totalSets));
-                setCounter += 1;
-
                 if(isFirstIntervalNotification) {
                     isFirstIntervalNotification = false;
                     return;
                 }
-                notificationBuilderAlarm.setContentTitle(String.format("Set number %d has completed!!", setCounter - 1));
+                notificationBuilderAlarm.setContentTitle(String.format("Set number %d has completed!!", setCounter));
+                setCounter += 1;
+                setsView.setText(TimerUtils.formatSets(setCounter, totalSets));
                 notificationManager.notify(notificationId, notificationBuilderAlarm.build());
             }
 
@@ -269,6 +268,8 @@ public class IntervalCountDownTimer {
             @Override
             public void onFinish() {
                 notificationBuilderAlarm.setContentTitle(String.format("Set number %d has completed!!", setCounter));
+                setCounter += 1;
+                setsView.setText(TimerUtils.formatSets(setCounter, totalSets));
                 notificationManager.notify(notificationId, notificationBuilderAlarm.build());
                 intervalTimer = createIntervalTimer(durationMillisUntilFinished, totalIntervalMillis);
                 intervalTimer.start();

--- a/app/src/main/java/com/example/intervaltimer/timer/TimerUtils.java
+++ b/app/src/main/java/com/example/intervaltimer/timer/TimerUtils.java
@@ -14,7 +14,7 @@ public class TimerUtils {
         int minutes = (int) ((millis / (1000*60)) % 60);
         int hours = (int) ((millis / (1000*60*60)) % 24);
         String time = String.format("%02d.%d", seconds, tenths);
-        if (minutes > 0) {
+        if (minutes > 0 || hours > 0) {
             time = String.format("%02d:", minutes) + time;
         }
         if (hours > 0) {

--- a/app/src/main/res/layout/activity_timer.xml
+++ b/app/src/main/res/layout/activity_timer.xml
@@ -73,7 +73,7 @@
         app:layout_constraintHorizontal_bias="0.5" />
 
     <TextView
-        android:id="@+id/number_of_beeps_val"
+        android:id="@+id/sets_val"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:autoSizeTextType="uniform"


### PR DESCRIPTION
- Changed number of sets to start at one
- Fixed formatting to time strings to include the minutes value whenever there are hours remaining (previously `01:00:59.000` would be shown as `01:59.000`, which look like 1 minute 59 seconds, but is actually 1 hour 0 minutes, 59 seconds)
- Made the interval progress line slightly shorter, so it doesn't overlap the total duration time